### PR TITLE
Add TutorialSearch to Learning Resources

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -118,7 +118,7 @@
 - [Neural Style Transfer: Creating Art with Deep Learning using tf.keras and eager execution](https://medium.com/tensorflow/neural-style-transfer-creating-art-with-deep-learning-using-tf-keras-and-eager-execution-7d541ac31398)
 - [Creative Applications of Deep Learning with TensorFlow (Parag Mital)](https://www.kadenze.com/courses/creative-applications-of-deep-learning-with-tensorflow/info)
 - [cs231n](http://cs231n.github.io/) - The notes accompany the Stanford Computer Science class CS231n (Convolutional Neural Networks for Visual Recognition).
-- [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
+- [TutorialSearch](https://tutorialsearch.io/browse/ai-machine-learning/cloud-machine) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 
 
 

--- a/readme.md
+++ b/readme.md
@@ -118,6 +118,7 @@
 - [Neural Style Transfer: Creating Art with Deep Learning using tf.keras and eager execution](https://medium.com/tensorflow/neural-style-transfer-creating-art-with-deep-learning-using-tf-keras-and-eager-execution-7d541ac31398)
 - [Creative Applications of Deep Learning with TensorFlow (Parag Mital)](https://www.kadenze.com/courses/creative-applications-of-deep-learning-with-tensorflow/info)
 - [cs231n](http://cs231n.github.io/) - The notes accompany the Stanford Computer Science class CS231n (Convolutional Neural Networks for Visual Recognition).
+- [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 
 
 


### PR DESCRIPTION
Hi! This PR adds **TutorialSearch** to the *Learning Resources* section.

### What is TutorialSearch?
[TutorialSearch](https://tutorialsearch.io/browse/ai-machine-learning/cloud-machine) is a free, cross-platform search engine that indexes 50,000+ tutorials and courses from major learning platforms (Udemy, Skillshare, Pluralsight, and more) across 45+ categories — including programming, web development, AI/ML, cybersecurity, design, and more. No signup required.

It helps learners compare tutorials side-by-side by rating, price, and reviews before committing to a course, which I think makes it a useful addition to this list.

### Entry added
```
- [TutorialSearch](https://tutorialsearch.io/browse/ai-machine-learning/cloud-machine) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
```

Inserted in alphabetical order within the section. Happy to adjust formatting, description length, or placement if you'd like — just let me know!

Thanks for maintaining this list.